### PR TITLE
New groups and space removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 A few examples are listed... Continue by fork and pull
 
 1. Student Developers Society
-
 - [Website](https://studevsoc.com)
 - [Telegram](https://t.me/studevsoc)
 - [Facebook](https://facebook.com/StuDevSoc)
@@ -16,13 +15,11 @@ A few examples are listed... Continue by fork and pull
 - [Gitlab](https://gitlab.com/studevsoc)
 
 2. Pehia
-
 - [Website](https://pehia.org)
 - [Instagram](https://instagram.com/pehiaorg)
 - [Twitter](https://twitter.com/pehiaorg)
 
 3. Tinkerhub
-
 - [Website](https://tinkerhub.org)
 - [Github](https://github.com/tinkerhub-org)
 - [Telegram](https://t.me/tinkerhub)
@@ -30,14 +27,12 @@ A few examples are listed... Continue by fork and pull
 - [Twitter](https://twitter.com/tinkerhub)
 
 4. TechCrawler
-
 - [Website](https://techcrawler.in)
 - [GitHub](https://github.com/techcrawler-community)
 - [Instagram](https://instagram.com/thetechcrawler)
 - [Discord](https://discord.gg/n7TmN6t)
 
 5. GDG Calicut
-
 - [Website](https://gdgkozhikode.org/)
 - [Github](https://github.com/GDGKozhikode)
 - [Facebook](https://www.facebook.com/GDGKozhikode/)
@@ -45,7 +40,6 @@ A few examples are listed... Continue by fork and pull
 - [Instagram](https://instagram.com/gdgkozhikode)
 
 6. GDG Cochin
-
 - [Website](https://gdgcochin.org/)
 - [Facebook](https://www.facebook.com/GDGCochin/)
 - [Twitter](https://twitter.com/gdgcochin)
@@ -53,7 +47,6 @@ A few examples are listed... Continue by fork and pull
 - [Telegram](https://t.me/GDGCochine)
 
 7. Hack Club
-
 - [Website](https://hackclub.com/)
 - [Slack](https://hackclub.com/slack/)
 - [Twitter](https://twitter.com/hackclub)
@@ -62,7 +55,6 @@ A few examples are listed... Continue by fork and pull
 - [Github](https://github.com/hackclub)
 
 8. Crossroads
-
 - [Website](https://crossroads.world/)
 - [Youtube](https://www.youtube.com/channel/UCoGHeFY7jE2OB_TJS_87MOA)
 - [Facebook](https://www.facebook.com/crossroadstalks)
@@ -70,7 +62,6 @@ A few examples are listed... Continue by fork and pull
 - [Telegram](https://t.me/crtalks)
 
 9. Coding Blocks
-
 - [Website](https://codingblocks.com/)
 - [Facebook](https://www.facebook.com/codingblocksindia)
 - [Twitter](https://twitter.com/codingblocksIN)
@@ -79,7 +70,6 @@ A few examples are listed... Continue by fork and pull
 - [Telegram](https://t.me/codingblocksplu)
 
 10. KuttyCoders
-
 - [Website](https://kuttycoders.in/)
 - [Github](https://github.com/kuttycoders)
 - [Youtube](https://www.youtube.com/channel/UCWKggpntkBS53IKGXxK8nIw)
@@ -88,7 +78,6 @@ A few examples are listed... Continue by fork and pull
 - [Twitter](https://twitter.com/kuttycoders)
 
 11. GirlScript
-
 - [Website](https://www.girlscript.tech/)
 - [Facebook](https://www.facebook.com/Girlscript/)
 - [Youtube](https://www.youtube.com/channel/UCBOlJtDcWNh0aUkS2CfI8Aw)
@@ -97,14 +86,12 @@ A few examples are listed... Continue by fork and pull
 - [Twitter](https://twitter.com/girlscript1)
 
 12. Kerala Rustaceans
-
 - [Mozilla Groups](https://community.mozilla.org/groups/kerala-rustaceans)
 - [Telegram](https://t.me/keralars)
 - [Twitter](https://twitter/keralars)
 - [GitHub](https://t.me/keralars)
 
 13. FAYA:80
-
 - [Website](https://www.fayaport80.com/)
 - [Facebook](https://www.facebook.com/fayaport80/)
 - [Twitter](https://twitter.com/FayaPort80)
@@ -112,7 +99,6 @@ A few examples are listed... Continue by fork and pull
 - [Eventbrite](https://www.eventbrite.com/o/faya-3194888760)
 
 14. MakerGram
-
 - [Website](https://makergram.com)
 - [Telegram](https://t.me/makergram)
 - [Twitter](https://twitter/Maker_Gram)
@@ -120,71 +106,57 @@ A few examples are listed... Continue by fork and pull
 - [LinkedIn](https://www.linkedin.com/company/makergram/)
 
 15. Kerala JUG
-
 - [Website](https://www.keralajug.org)
 - [Telegram](https://t.me/KeralaJUG)
 - [GitHub](https://github.com/keralajug)
 - [Twitter](https://twitter.com/KeralaJUG)
 
 16. AWS User group - Kochi
-
 - [Website](https://awsugkochi.in)
 - [GitHub](https://github.com/awsugkochi/awsugkochi)
 - [Meetup Group](https://www.meetup.com/awsugkochi/)
 
 17. Flutter Kerala
-
 - [GitHub](https://github.com/FlutterKerala)
 - [Twitter](https://twitter.com/flutterkerala)
 
 18. Headstart Calicut chapter
-
 - [Website](https://headstart.in/chapter/calicut)
 - [Twitter](https://twitter.com/HSCalicut)
 
 19. Kochi Python
-
 - [Website](https://kochi.python.org.in)
 - [Twitter](https://twitter.com/KochiPython)
 - [GitHub](https://github.com/KochiPython/)
 
 20. MALABAR AMATEUR RADIO SOCIETY
-
 - [Website](https://malabarradiosociety.in)
 
 21. Dair.ai
-
 - [Website](https://dair.ai/)
 - [Twitter](http://twitter.com/dair_ai)
 - [Github](http://github.com/dair-ai)
 
 22. Bearly Developers
-
 - [Telegram Chat](https://t.me/BEARlyDev)
 - [Telegram Channel](http://t.me/BEARlyLog)
 
 23. Bearly Infosec
-
 - [Telegram](https://t.me/BEARlySec)
 
 24. Bearly WebDev
-
 - [Telegram](https://t.me/BEARlyWeb)
 
 25. Bearly Science and Tech
-
 - [Telegram](https://t.me/BEARly_Sci_Tech)
 
 26. Bearly MobileDev
-
 - [Telegram](https://t.me/BEARlyMobile)
 
 27. CyberVally
-
 - [Twitter](https://twitter.com/cybervally)
 
 28. Collabnix
-
 - [Website](https://collabnix.com/)
 - [Slack](https://collabnix.slack.com/)
 - [Facebook](https://www.facebook.com/groups/1585441721723792/)
@@ -194,57 +166,46 @@ A few examples are listed... Continue by fork and pull
 - [Youtube](https://www.youtube.com/channel/UCyGUMSe_Y5zuYwrIQdJuLvw)
 
 29. DevTo
-
 - [Website](https://dev.to/)
 
 30. Hackernoon
-
 - [Website](https://hackernoon.com/)
 
 31. Hackerrank
-
 - [Website](https://www.hackerrank.com/)
 
 32. Daniweb
-
 - [Website](https://www.daniweb.com)
 - [Twitter](https://twitter.com/daniweb)
 
 33. CodeProject
-
 - [Website](https://www.codeproject.com/)
 
 34. Developers Forum
-
 - [Website](https://www.webdeveloper.com/)
 
 35. Coderwall
-
 - [Website](https://coderwall.com/)
 - [GitHub](https://github.com/coderwall)
 - [Twitter](https://twitter.com/coderwall)
 
 36. Coffeecup
-
 - [Website](https://www.coffeecup.com/)
 - [Twitter](https://www.twitter.com/coffeecup)
 - [Facebook](https://www.facebook.com/coffeecup)
 - [LinkedIn](https://www.linkedin.com/company/coffeecup-software)
 
 37. Facebook Developer circles kochi
-
 - [Facebook](https://www.facebook.com/groups/DevCKochi/)
 - [LinkedIn](https://www.linkedin.com/company/fbdevckochi?originalSubdomain=in)
 - [Instagram](https://www.instagram.com/devckochi/)
 
 38. Idoxploit
-
 - [Website](https://indoxploit.id/)
 - [Github](https://indoxploit.id/)
 - [Facebook](https://web.facebook.com/indoxploit)
 
 39. FAUN
-
 - [Website](https://faun.dev/)
 - [Medium](https://medium.com/faun)
 - [Slack](https://devopslinks.slack.com/)
@@ -252,7 +213,6 @@ A few examples are listed... Continue by fork and pull
 - [Facebook](https://www.facebook.com/faun.dev)
 
 40. ioetplanet
-
 - [Website](https://www.ioetplanet.com/)
 - [Slack](https://ioetplanet.slack.com/)
 - [GitHub](https://github.com/collabnix/ioetplanet)
@@ -261,6 +221,5 @@ A few examples are listed... Continue by fork and pull
 - [Twitter](https://twitter.com/ioetplanet)
 
 41. Papers We Love Kochi
-
 - [Website](https://paperswelove.org/)
 - [Telegram](https://t.me/pwl_kochi)

--- a/README.md
+++ b/README.md
@@ -223,3 +223,11 @@ A few examples are listed... Continue by fork and pull
 41. Papers We Love Kochi
 - [Website](https://paperswelove.org/)
 - [Telegram](https://t.me/pwl_kochi)
+
+42. Computer Science Portal
+- [Telegram](https://t.me/joinchat/Me9ZWRhqjhq56oDMJq3aGA)
+
+43. Trainings and Internships 2020
+- [Youtube](https://www.youtube.com/channel/UCUqLb3YfBCeGep0h26nfT2w/videos/)
+- [Telegram](https://t.me/placements2020GS)
+- [LinkedIn](https://www.linkedin.com/company/trainings-internships/)


### PR DESCRIPTION
Space added in the previous PR #26 was causing a critical problem. On the hosted page, the count of the list is not coming in series and all are marked as 1. Removed the spaces so the count can come back.
Added two new telegram groups - one for devs and other for training and placements.